### PR TITLE
 Fix the issue with mcMMO's Tree Feller

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/PlantsListener.java
@@ -373,18 +373,21 @@ public class PlantsListener implements Listener {
             for (int y = -1; y < 2; y++) {
                 for (int z = -1; z < 2; z++) {
                     // inspect a cube at the reference
-                    Block drop = block.getRelative(x, y, z);
-                    SlimefunItem check = BlockStorage.check(drop);
 
-                    if (check != null) {
-                        for (Tree tree : ExoticGarden.getTrees()) {
-                            if (check.getID().equalsIgnoreCase(tree.getFruitID())) {
-                                BlockStorage.clearBlockInfo(drop);
-                                ItemStack fruits = check.getItem();
-                                drop.getWorld().playEffect(drop.getLocation(), Effect.STEP_SOUND, Material.OAK_LEAVES);
-                                drop.getWorld().dropItemNaturally(drop.getLocation(), fruits);
-                                drop.setType(Material.AIR);
-                            }
+                    Block fruit = block.getRelative(x, y, z);
+                    if (fruit.isEmpty()) continue;
+
+                    Location loc = fruit.getLocation();
+                    SlimefunItem check = BlockStorage.check(loc);
+                    if (check == null) continue;
+
+                    for (Tree tree : ExoticGarden.getTrees()) {
+                        if (check.getID().equalsIgnoreCase(tree.getFruitID())) {
+                            BlockStorage.clearBlockInfo(loc);
+                            ItemStack fruits = check.getItem();
+                            fruit.getWorld().playEffect(loc, Effect.STEP_SOUND, Material.OAK_LEAVES);
+                            fruit.getWorld().dropItemNaturally(loc, fruits);
+                            fruit.setType(Material.AIR);
                         }
                     }
                 }

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/PlantsListener.java
@@ -373,7 +373,6 @@ public class PlantsListener implements Listener {
             for (int y = -1; y < 2; y++) {
                 for (int z = -1; z < 2; z++) {
                     // inspect a cube at the reference
-
                     Block fruit = block.getRelative(x, y, z);
                     if (fruit.isEmpty()) continue;
 
@@ -388,6 +387,7 @@ public class PlantsListener implements Listener {
                             fruit.getWorld().playEffect(loc, Effect.STEP_SOUND, Material.OAK_LEAVES);
                             fruit.getWorld().dropItemNaturally(loc, fruits);
                             fruit.setType(Material.AIR);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Should resolve #147 and resolve #7 (wow, it's been a while).

Currently removing fruits is done one tick later because of BlockStorage's queue. During that time mcMMO calls a few block break events. So while we did remove our fruit, it's still present in the memory, and the code produces the drop again.

We can either replace `clearBlockInfo()` with `_integrated_removeBlockInfo()` or check if that block was already set to AIR. I've used the second approach.

*Also added the `break` statement when we found our fruit.*