### PR TITLE
Crook functioning as hoe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/Crook.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/Crook.java
@@ -3,6 +3,8 @@ package io.github.thebusybiscuit.exoticgarden.items;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -22,6 +24,11 @@ public class Crook extends SimpleSlimefunItem<BlockBreakHandler> implements NotP
 
     public Crook(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
+    }
+
+    @Override
+    public void preRegister() {
+        addItemHandler((ItemUseHandler) PlayerRightClickEvent::cancel);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/Crook.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/Crook.java
@@ -24,11 +24,12 @@ public class Crook extends SimpleSlimefunItem<BlockBreakHandler> implements NotP
 
     public Crook(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
+        addItemHandler(onRightClick());
     }
 
-    @Override
-    public void preRegister() {
-        addItemHandler((ItemUseHandler) PlayerRightClickEvent::cancel);
+
+    private ItemUseHandler onRightClick() {
+        return PlayerRightClickEvent::cancel;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/Kitchen.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/Kitchen.java
@@ -27,7 +27,7 @@ import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
 
 public class Kitchen extends MultiBlockMachine {
 
-    private ExoticGarden plugin;
+    private final ExoticGarden plugin;
 
     public Kitchen(ExoticGarden plugin, Category category) {
         super(category, new SlimefunItemStack("KITCHEN", Material.CAULDRON, "&eKitchen", "", "&a&oYou can make a bunch of different yummies here!", "&a&oThe result goes in the Furnace output slot"), new ItemStack[] { new CustomItem(Material.BRICK_STAIRS, "&oBrick Stairs (upside down)"), new CustomItem(Material.BRICK_STAIRS, "&oBrick Stairs (upside down)"), new ItemStack(Material.BRICKS), new ItemStack(Material.STONE_PRESSURE_PLATE), new ItemStack(Material.IRON_TRAPDOOR), new ItemStack(Material.BOOKSHELF), new ItemStack(Material.FURNACE), new ItemStack(Material.DISPENSER), new ItemStack(Material.CRAFTING_TABLE) }, new ItemStack[0], BlockFace.SELF);


### PR DESCRIPTION
Fixed issue i reported on SlimyTreeTaps

Added ItemHandler that cancels right click, Added this because the crook worked as a hoe.
also added final, intelij complained about it

yes i tested my changes
no i didnt leave documentation or added unit tests