### PR TITLE
Add Dirt Plant

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/ExoticGarden.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/ExoticGarden.java
@@ -1,6 +1,12 @@
 package io.github.thebusybiscuit.exoticgarden;
 
-import io.github.thebusybiscuit.exoticgarden.items.*;
+import io.github.thebusybiscuit.exoticgarden.items.Crook;
+import io.github.thebusybiscuit.exoticgarden.items.CustomFood;
+import io.github.thebusybiscuit.exoticgarden.items.ExoticGardenFruit;
+import io.github.thebusybiscuit.exoticgarden.items.FoodRegistry;
+import io.github.thebusybiscuit.exoticgarden.items.GrassSeeds;
+import io.github.thebusybiscuit.exoticgarden.items.Kitchen;
+import io.github.thebusybiscuit.exoticgarden.items.MagicalEssence;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.researching.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
@@ -20,7 +26,12 @@ import me.mrCookieSlime.Slimefun.cscorelib2.skull.SkullItem;
 import me.mrCookieSlime.Slimefun.cscorelib2.updater.GitHubBuildsUpdater;
 import me.mrCookieSlime.Slimefun.cscorelib2.updater.Updater;
 import org.bstats.bukkit.Metrics;
-import org.bukkit.*;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
@@ -34,7 +45,13 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 
 public class ExoticGarden extends JavaPlugin implements SlimefunAddon {

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/ExoticGarden.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/ExoticGarden.java
@@ -1,42 +1,6 @@
 package io.github.thebusybiscuit.exoticgarden;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.logging.Level;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.bstats.bukkit.Metrics;
-import org.bukkit.ChatColor;
-import org.bukkit.Color;
-import org.bukkit.Effect;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Tag;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
-
-import io.github.thebusybiscuit.exoticgarden.items.Crook;
-import io.github.thebusybiscuit.exoticgarden.items.CustomFood;
-import io.github.thebusybiscuit.exoticgarden.items.ExoticGardenFruit;
-import io.github.thebusybiscuit.exoticgarden.items.FoodRegistry;
-import io.github.thebusybiscuit.exoticgarden.items.GrassSeeds;
-import io.github.thebusybiscuit.exoticgarden.items.Kitchen;
-import io.github.thebusybiscuit.exoticgarden.items.MagicalEssence;
+import io.github.thebusybiscuit.exoticgarden.items.*;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.researching.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
@@ -55,6 +19,23 @@ import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
 import me.mrCookieSlime.Slimefun.cscorelib2.skull.SkullItem;
 import me.mrCookieSlime.Slimefun.cscorelib2.updater.GitHubBuildsUpdater;
 import me.mrCookieSlime.Slimefun.cscorelib2.updater.Updater;
+import org.bstats.bukkit.Metrics;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.logging.Level;
 
 public class ExoticGarden extends JavaPlugin implements SlimefunAddon {
 
@@ -153,6 +134,9 @@ public class ExoticGarden extends JavaPlugin implements SlimefunAddon {
 		registerTree("Dragon Fruit", "847d73a91b52393f2c27e453fb89ab3d784054d414e390d58abd22512edd2b", "&d", Color.FUCHSIA, "Dragon Fruit Juice", true, Material.DIRT, Material.GRASS_BLOCK);
 
 		FoodRegistry.register(this, miscCategory, drinksCategory, foodCategory);
+
+		registerMagicalPlant("Dirt", new ItemStack(Material.DIRT, 2), "1ab43b8c3d34f125e5a3f8b92cd43dfd14c62402c33298461d4d4d7ce2d3aea",
+		new ItemStack[] {null, new ItemStack(Material.DIRT), null, new ItemStack(Material.DIRT), new ItemStack(Material.WHEAT_SEEDS), new ItemStack(Material.DIRT), null, new ItemStack(Material.DIRT), null});
 
 		registerMagicalPlant("Coal", new ItemStack(Material.COAL, 2), "7788f5ddaf52c5842287b9427a74dac8f0919eb2fdb1b51365ab25eb392c47",
 		new ItemStack[] {null, new ItemStack(Material.COAL_ORE), null, new ItemStack(Material.COAL_ORE), new ItemStack(Material.WHEAT_SEEDS), new ItemStack(Material.COAL_ORE), null, new ItemStack(Material.COAL_ORE), null});


### PR DESCRIPTION
Additions:
Adds Dirt Plant
Magical Essence to use 8 to create 2 dirt

Changes:
Some above imports that are redundant. (If not wanted can be removed)