### PR TITLE
Change getFoodValue() from protected to public

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/CustomFood.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/CustomFood.java
@@ -21,7 +21,7 @@ public class CustomFood extends ExoticGardenFruit {
     }
 
     @Override
-    protected int getFoodValue() {
+    public int getFoodValue() {
         return food;
     }
 


### PR DESCRIPTION
There is no currently discernable reason why getFoodValue() is protected.

Making this public would let other plugins get the value to either be displayed or otherwise used.