### PR TITLE
Add option to disable bonemeal

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/ExoticGarden.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/ExoticGarden.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.exoticgarden;
 
+import io.github.thebusybiscuit.exoticgarden.items.BonemealableItem;
 import io.github.thebusybiscuit.exoticgarden.items.Crook;
 import io.github.thebusybiscuit.exoticgarden.items.CustomFood;
 import io.github.thebusybiscuit.exoticgarden.items.ExoticGardenFruit;
@@ -269,7 +270,7 @@ public class ExoticGarden extends JavaPlugin implements SlimefunAddon {
 
         items.put(id + "_SAPLING", sapling);
 
-        new SlimefunItem(mainCategory, sapling, ExoticGardenRecipeTypes.BREAKING_GRASS, new ItemStack[] { null, null, null, null, new ItemStack(Material.GRASS), null, null, null, null }).register(this);
+        new BonemealableItem(mainCategory, sapling, ExoticGardenRecipeTypes.BREAKING_GRASS, new ItemStack[] { null, null, null, null, new ItemStack(Material.GRASS), null, null, null, null }).register(this);
 
         new ExoticGardenFruit(mainCategory, new SlimefunItemStack(id, texture, color + name), ExoticGardenRecipeTypes.HARVEST_TREE, true, new ItemStack[] { null, null, null, null, getItem(id + "_SAPLING"), null, null, null, null }).register(this);
 
@@ -310,7 +311,7 @@ public class ExoticGarden extends JavaPlugin implements SlimefunAddon {
 
         items.put(upperCase + "_BUSH", sfi);
 
-        new SlimefunItem(mainCategory, sfi, ExoticGardenRecipeTypes.BREAKING_GRASS, new ItemStack[] { null, null, null, null, new ItemStack(Material.GRASS), null, null, null, null }).register(this);
+        new BonemealableItem(mainCategory, sfi, ExoticGardenRecipeTypes.BREAKING_GRASS, new ItemStack[] { null, null, null, null, new ItemStack(Material.GRASS), null, null, null, null }).register(this);
 
         new ExoticGardenFruit(mainCategory, new SlimefunItemStack(upperCase, texture, color + name), ExoticGardenRecipeTypes.HARVEST_BUSH, true, new ItemStack[] { null, null, null, null, getItem(upperCase + "_BUSH"), null, null, null, null }).register(this);
 
@@ -339,7 +340,8 @@ public class ExoticGarden extends JavaPlugin implements SlimefunAddon {
         SlimefunItemStack bush = new SlimefunItemStack(enumStyle + "_BUSH", Material.OAK_SAPLING, color + name + " Plant");
         items.put(upperCase + "_BUSH", bush);
 
-        new SlimefunItem(mainCategory, bush, ExoticGardenRecipeTypes.BREAKING_GRASS, new ItemStack[] { null, null, null, null, new ItemStack(Material.GRASS), null, null, null, null }).register(this);
+        new BonemealableItem(mainCategory, bush, ExoticGardenRecipeTypes.BREAKING_GRASS, new ItemStack[] { null, null, null, null, new ItemStack(Material.GRASS), null, null, null, null })
+            .register(this);
 
         new ExoticGardenFruit(mainCategory, new SlimefunItemStack(enumStyle, texture, color + name), ExoticGardenRecipeTypes.HARVEST_BUSH, true, new ItemStack[] { null, null, null, null, getItem(enumStyle + "_BUSH"), null, null, null, null }).register(this);
     }
@@ -353,7 +355,8 @@ public class ExoticGarden extends JavaPlugin implements SlimefunAddon {
         Berry berry = new Berry(essence, upperCase + "_ESSENCE", PlantType.ORE_PLANT, texture);
         berries.add(berry);
 
-        new SlimefunItem(magicalCategory, new SlimefunItemStack(enumStyle + "_PLANT", Material.OAK_SAPLING, "&r" + name + " Plant"), RecipeType.ENHANCED_CRAFTING_TABLE, recipe).register(this);
+        new BonemealableItem(magicalCategory, new SlimefunItemStack(enumStyle + "_PLANT", Material.OAK_SAPLING, "&r" + name + " Plant"), RecipeType.ENHANCED_CRAFTING_TABLE, recipe)
+            .register(this);
 
         MagicalEssence magicalEssence = new MagicalEssence(magicalCategory, essence);
 

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
@@ -7,10 +7,16 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import org.bukkit.inventory.ItemStack;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * This class has a {@link ItemSetting} to disable bonemeal usage on this {@link SlimefunItem}.
+ */
 public class BonemealableItem extends SlimefunItem {
 
     private final ItemSetting<Boolean> disableBoneMeal = new ItemSetting<>("disable-bonemeal", false);
 
+    @ParametersAreNonnullByDefault
     public BonemealableItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
@@ -13,6 +13,8 @@ public class BonemealableItem extends SlimefunItem {
 
     public BonemealableItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
+
+        addItemSetting(disableBoneMeal);
     }
 
     public boolean isBonemealDisabled() {

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
@@ -1,0 +1,21 @@
+package io.github.thebusybiscuit.exoticgarden.items;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import org.bukkit.inventory.ItemStack;
+
+public class BonemealableItem extends SlimefunItem {
+
+    private final ItemSetting<Boolean> disableBoneMeal = new ItemSetting<>("disable-bonemeal", false);
+
+    public BonemealableItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+    }
+
+    public boolean isBonemealDisabled() {
+        return disableBoneMeal.getValue();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/BonemealableItem.java
@@ -10,7 +10,9 @@ import org.bukkit.inventory.ItemStack;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * This class has a {@link ItemSetting} to disable bonemeal usage on this {@link SlimefunItem}.
+ * This class has an {@link ItemSetting} to disable bonemeal usage on this {@link SlimefunItem}.
+ *
+ * @author Walshy
  */
 public class BonemealableItem extends SlimefunItem {
 

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -383,13 +383,14 @@ public class PlantsListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onBonemealPlant(BlockFertilizeEvent e) {
-        if (e.getBlock().getType() == Material.OAK_SAPLING) {
-            SlimefunItem item = BlockStorage.check(e.getBlock());
+        Block b = e.getBlock();
+        if (b.getType() == Material.OAK_SAPLING) {
+            SlimefunItem item = BlockStorage.check(b);
 
             if (item instanceof BonemealableItem && ((BonemealableItem) item).isBonemealDisabled()) {
                 e.setCancelled(true);
-                e.getBlock().getWorld().spawnParticle(Particle.VILLAGER_ANGRY, e.getBlock().getLocation().clone().add(0.5, 0, 0.5), 4);
-                e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
+                b.getWorld().spawnParticle(Particle.VILLAGER_ANGRY, b.getLocation().clone().add(0.5, 0, 0.5), 4);
+                b.getWorld().playSound(b.getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -11,6 +11,8 @@ import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -379,13 +381,15 @@ public class PlantsListener implements Listener {
         e.blockList().removeAll(getAffectedBlocks(e.blockList()));
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBonemealPlant(BlockFertilizeEvent e) {
         if (e.getBlock().getType() == Material.OAK_SAPLING) {
             SlimefunItem item = BlockStorage.check(e.getBlock());
 
             if (item instanceof BonemealableItem && ((BonemealableItem) item).isBonemealDisabled()) {
                 e.setCancelled(true);
+                e.getBlock().getWorld().spawnParticle(Particle.VILLAGER_ANGRY, e.getBlock().getLocation().clone().add(0.5, 0, 0.5), 4);
+                e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_VILLAGER_NO, 1, 1);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -22,6 +22,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockFertilizeEvent;
 import org.bukkit.event.block.LeavesDecayEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -375,6 +376,17 @@ public class PlantsListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent e) {
         e.blockList().removeAll(getAffectedBlocks(e.blockList()));
+    }
+
+    @EventHandler
+    public void onBonemealPlant(BlockFertilizeEvent e) {
+        if (e.getBlock().getType() == Material.OAK_SAPLING) {
+            SlimefunItem item = BlockStorage.check(e.getBlock());
+
+            if (item != null && ExoticGarden.getInstance().getConfig().getBoolean("disable-bonemeal", false)) {
+                e.setCancelled(true);
+            }
+        }
     }
 
     private Set<Block> getAffectedBlocks(List<Block> blockList) {

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
+import io.github.thebusybiscuit.exoticgarden.items.BonemealableItem;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -383,7 +384,7 @@ public class PlantsListener implements Listener {
         if (e.getBlock().getType() == Material.OAK_SAPLING) {
             SlimefunItem item = BlockStorage.check(e.getBlock());
 
-            if (item != null && ExoticGarden.getInstance().getConfig().getBoolean("disable-bonemeal", false)) {
+            if (item instanceof BonemealableItem && ((BonemealableItem) item).isBonemealDisabled()) {
                 e.setCancelled(true);
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,4 @@
 grass-drops: []
-disable-bonemeal: false
 world-blacklist:
 - world_nether
 - world_the_end

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 grass-drops: []
+disable-bonemeal: false
 world-blacklist:
 - world_nether
 - world_the_end


### PR DESCRIPTION
Suggestion #958 by Boompie#2303 was to disable bonemeal on EG plants. This is to prevent the quick production of things like the netherite plant. Depending on the server eco, this could be relatively bad.

Either way, simple change and defaults to false in order to maintain current usage.