### PR TITLE
Fix fruits being able to place on cauldron

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/items/ExoticGardenFruit.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/items/ExoticGardenFruit.java
@@ -73,7 +73,6 @@ public class ExoticGardenFruit extends SimpleSlimefunItem<ItemUseHandler> {
             case HOPPER:
             case TRAPPED_CHEST:
             case ENDER_CHEST:
-            case CAULDRON:
             case SHULKER_BOX:
                 return true;
             default:


### PR DESCRIPTION
## Description
Removed cauldron from ExoticGardenFruit#isInteractable because it can be only interacted with bottles or buckets
## Related Issues
#159 
#199 
#224 