### PR TITLE
Performance Improvements

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/Berry.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/Berry.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.exoticgarden;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.EnumSet;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -12,6 +12,8 @@ import org.bukkit.inventory.ItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 
 public class Berry {
+
+    private static final Set<Material> SOILS = EnumSet.of(Material.GRASS_BLOCK, Material.DIRT);
 
     private final ItemStack item;
     private final String id;
@@ -59,8 +61,7 @@ public class Berry {
     }
 
     public boolean isSoil(Material type) {
-        List<Material> soils = Arrays.asList(Material.GRASS_BLOCK, Material.DIRT);
-        return soils.contains(type);
+        return SOILS.contains(type);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/Tree.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/Tree.java
@@ -3,7 +3,8 @@ package io.github.thebusybiscuit.exoticgarden;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
+import java.util.EnumSet;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -16,7 +17,7 @@ public class Tree {
     private final String sapling;
     private final String texture;
     private final String fruit;
-    private final List<Material> soils;
+    private final Collection<Material> soils;
 
     private Schematic schematic;
 
@@ -24,7 +25,7 @@ public class Tree {
         this.sapling = fruit + "_SAPLING";
         this.texture = texture;
         this.fruit = fruit;
-        this.soils = Arrays.asList(soil);
+        this.soils = EnumSet.copyOf(Arrays.asList(soil));
     }
 
     public Schematic getSchematic() throws IOException {

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -301,7 +301,7 @@ public class PlantsListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onHarvest(BlockBreakEvent e) {
         if (Slimefun.getProtectionManager().hasPermission(e.getPlayer(), e.getBlock().getLocation(), Interaction.BREAK_BLOCK)) {
-            if (e.getBlock().getType().equals(Material.PLAYER_HEAD) || Tag.LEAVES.isTagged(e.getBlock().getType())) {
+            if (e.getBlock().getType() == Material.PLAYER_HEAD || Tag.LEAVES.isTagged(e.getBlock().getType())) {
                 dropFruitFromTree(e.getBlock());
             }
 

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/schematics/Schematic.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/schematics/Schematic.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Rotatable;
@@ -125,15 +126,23 @@ public class Schematic {
         short width = schematic.getWidth();
         short height = schematic.getHeight();
 
+        // Performance - avoid repeatedly running Math.floorDiv in a loop
+        int initialBlockX = loc.getBlockX() - length / 2;
+        int initialBlockY = loc.getBlockY();
+        int initialBlockZ = loc.getBlockZ() - width / 2;
+
+        // Performance - avoid repeatedly checking if the world has been unloaded
+        World world = loc.getWorld();
+
         for (int x = 0; x < width; ++x) {
             for (int y = 0; y < height; ++y) {
                 for (int z = 0; z < length; ++z) {
                     int index = y * width * length + z * width + x;
 
-                    int blockX = x + loc.getBlockX() - length / 2;
-                    int blockY = y + loc.getBlockY();
-                    int blockZ = z + loc.getBlockZ() - width / 2;
-                    Block block = new Location(loc.getWorld(), blockX, blockY, blockZ).getBlock();
+                    int blockX = x + initialBlockX;
+                    int blockY = y + initialBlockY;
+                    int blockZ = z + initialBlockZ;
+                    Block block = world.getBlockAt(blockX, blockY, blockZ);
                     Material blockType = block.getType();
                     
                     if ((!blockType.isSolid() && !blockType.isInteractable() && !SlimefunTag.UNBREAKABLE_MATERIALS.isTagged(blockType)) || blockType == Material.AIR || blockType == Material.CAVE_AIR || org.bukkit.Tag.SAPLINGS.isTagged(blockType)) {


### PR DESCRIPTION
I haven't tested/benchmarked the changes of this PR on a live server just yet. 

This PR adds non-breaking performance improvements in various places. 
- Pasting schematics should be faster, owing to fewer calls to `Math.floorDiv` and `Location.getWorld`
- (More of a micro-optimisation here), `List<Material>` which only have `contains` calls have been replaced with `EnumSet`