### PR TITLE
Fixed interaction with Brewery cauldrons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,5 +135,12 @@
             <version>2.2.1</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.DieReicheErethons</groupId>
+            <artifactId>Brewery</artifactId>
+            <version>3.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,3 +9,6 @@ main: io.github.thebusybiscuit.exoticgarden.ExoticGarden
 
 depend:
 - Slimefun
+
+softdepend:
+- Brewery


### PR DESCRIPTION
Cauldrons for making brews in the Brewery plugin can now take ExoticGarden fruits again. Regular cauldrons will not be interactable, preventing fruit placement and bush duplication exploit. When brewery is not installed `isBreweryCauldron()` returns false causing it not to be interactable, as expected.

Fixes:
- https://github.com/DieReicheErethons/Brewery/issues/414
- Pull-request #209 