### PR TITLE
Update PlantsListener.java

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -353,7 +353,7 @@ public class PlantsListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onInteract(PlayerInteractEvent e) {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (e.getHand() != EquipmentSlot.HAND) return;


### PR DESCRIPTION
As per @bloodmc in the Slimefun discord

> Any reason why this isn't ignoring cancelled events? If a user cancels the interact event in Griefdefender, the item always drops due to this
GD doesn't depend on any other protection. It detects slimefun blocks/items on its own
I am aware that slimefun has its own protection manager but isn't used for GD
The event needs to ignore cancelled events.
The dev does this in other handlers but not this one.