### PR TITLE
Fixed duplication of falling blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -353,11 +353,41 @@ public class PlantsListener implements Listener {
         }
     }
 
+    Material[] blockedMaterials = new Material[] {
+    Material.ANVIL,
+    Material.CHIPPED_ANVIL,
+    Material.DAMAGED_ANVIL,
+    Material.DRAGON_EGG,
+    Material.SAND,
+    Material.RED_SAND,
+    Material.GRAVEL,
+    Material.SCAFFOLDING,
+    Material.WHITE_CONCRETE_POWDER,
+    Material.ORANGE_CONCRETE_POWDER,
+    Material.MAGENTA_CONCRETE_POWDER,
+    Material.LIGHT_BLUE_CONCRETE_POWDER,
+    Material.YELLOW_CONCRETE_POWDER,
+    Material.LIME_CONCRETE_POWDER,
+    Material.PINK_CONCRETE_POWDER,
+    Material.GRAY_CONCRETE_POWDER,
+    Material.LIGHT_GRAY_CONCRETE_POWDER,
+    Material.CYAN_CONCRETE_POWDER,
+    Material.PURPLE_CONCRETE_POWDER,
+    Material.BLUE_CONCRETE_POWDER,
+    Material.BROWN_CONCRETE_POWDER,
+    Material.GREEN_CONCRETE_POWDER,
+    Material.RED_CONCRETE_POWDER,
+    Material.BLACK_CONCRETE_POWDER,
+    };
+    
     @EventHandler
     public void onInteract(PlayerInteractEvent e) {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (e.getHand() != EquipmentSlot.HAND) return;
         if (e.getPlayer().isSneaking()) return;
+        for(Material mat : blockedMaterials) {
+        if(mat == e.getPlayer().getInventory().getItemInMainHand().getType() || mat == e.getPlayer().getInventory().getItemInOffHand().getType()) return;
+        }
 
         if (Slimefun.getProtectionManager().hasPermission(e.getPlayer(), e.getClickedBlock().getLocation(), Interaction.BREAK_BLOCK)) {
             ItemStack item = ExoticGarden.harvestPlant(e.getClickedBlock());

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
@@ -47,6 +49,8 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.skins.PlayerHead;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.skins.PlayerSkin;
 import io.github.thebusybiscuit.slimefun4.libraries.paperlib.PaperLib;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
+import static io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag.values;
 
 public class PlantsListener implements Listener {
 
@@ -353,41 +357,18 @@ public class PlantsListener implements Listener {
         }
     }
 
-    Material[] blockedMaterials = new Material[] {
-    Material.ANVIL,
-    Material.CHIPPED_ANVIL,
-    Material.DAMAGED_ANVIL,
-    Material.DRAGON_EGG,
-    Material.SAND,
-    Material.RED_SAND,
-    Material.GRAVEL,
-    Material.SCAFFOLDING,
-    Material.WHITE_CONCRETE_POWDER,
-    Material.ORANGE_CONCRETE_POWDER,
-    Material.MAGENTA_CONCRETE_POWDER,
-    Material.LIGHT_BLUE_CONCRETE_POWDER,
-    Material.YELLOW_CONCRETE_POWDER,
-    Material.LIME_CONCRETE_POWDER,
-    Material.PINK_CONCRETE_POWDER,
-    Material.GRAY_CONCRETE_POWDER,
-    Material.LIGHT_GRAY_CONCRETE_POWDER,
-    Material.CYAN_CONCRETE_POWDER,
-    Material.PURPLE_CONCRETE_POWDER,
-    Material.BLUE_CONCRETE_POWDER,
-    Material.BROWN_CONCRETE_POWDER,
-    Material.GREEN_CONCRETE_POWDER,
-    Material.RED_CONCRETE_POWDER,
-    Material.BLACK_CONCRETE_POWDER,
-    };
+    private static final Map<String, SlimefunTag> nameLookup = new HashMap<>();
+    private static final SlimefunTag[] valuesCache = values();
     
     @EventHandler
     public void onInteract(PlayerInteractEvent e) {
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (e.getHand() != EquipmentSlot.HAND) return;
         if (e.getPlayer().isSneaking()) return;
-        for(Material mat : blockedMaterials) {
-        if(mat == e.getPlayer().getInventory().getItemInMainHand().getType() || mat == e.getPlayer().getInventory().getItemInOffHand().getType()) return;
-        }
+        for (SlimefunTag tag : valuesCache) {
+            nameLookup.put(tag.name(), SlimefunTag.GRAVITY_AFFECTED_BLOCKS);
+            if(tag.isTagged(mainHand) || tag.isTagged(offHand)) return;
+            }
 
         if (Slimefun.getProtectionManager().hasPermission(e.getPlayer(), e.getClickedBlock().getLocation(), Interaction.BREAK_BLOCK)) {
             ItemStack item = ExoticGarden.harvestPlant(e.getClickedBlock());


### PR DESCRIPTION
You could right click these items onto the bottom of plants and duplicate them, as they would stay in place and get dropped as well causing 2 items to appear. This fixes that.