### PR TITLE
Feat: add the ability to change seed droprate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea
 target
 dependency-reduced-pom.xml
+settings.json

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -309,7 +309,7 @@ public class PlantsListener implements Listener {
                 if (!ExoticGarden.getGrassDrops().keySet().isEmpty() && e.getPlayer().getGameMode() != GameMode.CREATIVE) {
                     Random random = ThreadLocalRandom.current();
 
-                    if (random.nextInt(100) < 6) {
+                    if (random.nextInt(100) < cfg.getInt("chances.SEEDSDROP")) {
                         ItemStack[] items = ExoticGarden.getGrassDrops().values().toArray(new ItemStack[0]);
                         e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), items[random.nextInt(items.length)]);
                     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,5 +5,6 @@ world-blacklist:
 chances:
   TREE: 22
   BUSH: 16
+  SEEDSDROP: 6
 options:
   auto-update: true


### PR DESCRIPTION
Seed droprates caused a lot of imbalance in my server, so I added a feature to modify the drop rate though config.yml.

This has been tested on my server, and _should_ work flawlessly— it's a rather simple implementation, though I'm welcome to more robust alternatives.